### PR TITLE
enable test coverage for code climate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group :test do
 	#gem 'selenium-webdriver'
 	gem 'rails-perftest'
 	gem 'ruby-prof'
+	gem "codeclimate-test-reporter", require: nil
 end
 
 # Use Devise for user authentication

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
       xpath (~> 2.0)
     chartkick (1.3.2)
     chunky_png (1.3.4)
+    codeclimate-test-reporter (0.4.7)
+      simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -89,6 +91,7 @@ GEM
       responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
+    docile (1.1.5)
     dogapi (1.17.0)
       multi_json
     erubis (2.7.0)
@@ -272,6 +275,11 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     spring (1.3.4)
     sprockets (2.12.3)
       hike (~> 1.2)
@@ -336,6 +344,7 @@ DEPENDENCIES
   capistrano-rvm
   capybara
   chartkick
+  codeclimate-test-reporter
   coffee-rails (~> 4.0.0)
   compass-rails
   dateslices

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,8 @@
-# -*- encoding : utf-8 -*-
 ENV["RAILS_ENV"] = "test"
+
+require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start
+
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'webmock/minitest'


### PR DESCRIPTION
Add Code Climate gem and enable their test reporter so that we can get metrics on test coverage from Travis CI.