### PR TITLE
allow net communication outside tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,7 @@ class ActiveSupport::TestCase
 
 	def teardown
 		Rails.cache.clear rescue nil
+		WebMock.allow_net_connect!
 	end
 end
 


### PR DESCRIPTION
We need to allow communication with codeclimate.com
after all tests are finished, so we call WebMock.allow_net_connect
in teardown.