### PR TITLE
Improve management of images

### DIFF
--- a/app/assets/javascripts/base/forms.js.coffee.erb
+++ b/app/assets/javascripts/base/forms.js.coffee.erb
@@ -205,6 +205,27 @@ checkboxClicked = (element) ->
 	crack_speed = speed
 	crack_time_text = tooltip_text
 	
+#
+# Update preview image of a given url input.
+#
+updateImagePreview = (input) ->
+	image = $('#'+input.data('preview'))
+	size = image.data('preview-size')
+	size ?= 128 # default size
+	size = 256 # TODO: remove when we have missing.png for every size
+	default_url = "/assets/gfx/icons/#{size}/missing.png"
+	
+	url = input.val()
+	url = default_url if !url # if null or empty
+	
+	$('<img/>', {
+		src: url
+		error: ->
+			image.attr 'src', default_url
+		load: ->
+			image.attr 'src', url
+	})
+	
 $(document).on 'contentReady', () ->
 	refreshLoginMode()
 	$("#login [data-button='toggle']").when 'click.form.toggle', (event) ->
@@ -216,12 +237,19 @@ $(document).on 'contentReady', () ->
 	$("form [data-submitOnEnter]").when 'keydown.form.submit', (event) ->
 		if pressedEnter event
 			submitLoginForm $(this)
+			
+	$('form [data-preview]').when 'change.form.preview keyup.form.preview paste.form.preview', ->
+		updateImagePreview $(@)
+	for x in $('form [data-preview]')
+		updateImagePreview $(x)
+		
 	$("#crack-time-img").qtip {
 		content: crack_time_text,
 		style: 'qtip-light qtip-shadow'
 	}
 	$('form[data-loading]').when 'submit.form', ->
 		$('#'+ $(@).data('loading') + ' .loading').show()
+		
 	$('textarea').autosize()
 	for dd in $('[data-imageselect]')
 		dd = $(dd)

--- a/app/assets/javascripts/modules/dialog.js.coffee
+++ b/app/assets/javascripts/modules/dialog.js.coffee
@@ -2,8 +2,9 @@ isOpening = false
 
 @closeDialog = () ->
 	$('#dialog-overlay').fadeOut()
+	$('header').removeClass 'under-dialog'
 
-@openDialog = (url, options) ->
+@openDialog = (url, options = {}) ->
 	$.extend true, { mode: 'float' }, options
 	if options['mode'] == 'inline' and not 'parent' in options
 		$.error 'You must specify parent if you use inline dialog mode.'
@@ -23,6 +24,7 @@ isOpening = false
 	$('#dialog #content').hide()
 	$('#dialog .alert').hide()
 	$('#dialog .loading').show()
+	$('header').addClass 'under-dialog'
 	
 	$('#dialog-overlay').fadeIn (event) ->
 		isOpening = false

--- a/app/assets/javascripts/modules/editable.js.coffee
+++ b/app/assets/javascripts/modules/editable.js.coffee
@@ -53,6 +53,13 @@ submitEditable = (element) ->
 	}
 	
 	deactivateEditable element
+	
+#
+# Open a dialog to edit image URLs.
+#
+editableImageClicked = (element) ->
+	url = element.data('imageable-url')
+	openDialog url
 
 $(document).on 'contentReady', () ->
 	$('.editable').when 'click.editable', (event) ->
@@ -68,3 +75,6 @@ $(document).on 'contentReady', () ->
 		
 	$(".editable input[type='text']").when 'blur.editable', (event) ->
 		deactivateEditable $(@).parent('.editable')
+		
+	$('.editable-image .overlay').when 'click.editableimg', (event) ->
+		editableImageClicked $(@).parent('.editable-image')

--- a/app/assets/stylesheets/base/forms.css.scss
+++ b/app/assets/stylesheets/base/forms.css.scss
@@ -12,6 +12,9 @@ form
 			width: 12em;
 			max-width: 100%;
 			background: transparent;
+			text-overflow: ellipsis;
+			
+			&.wide { width: 25em; }
 		}
 		
 		input, textarea, select, 
@@ -41,11 +44,26 @@ form
 			&:after { content: ':'; }
 		}
 		
+		img.preview
+		{
+			display: block;
+			margin: 0 auto 3em;
+		}
+		
 		&:after
 		{
 			display: block;
 			content: '';
 			clear: both;
+		}
+	}
+	
+	div.previewable
+	{
+		text-align: left;
+		img.preview, div.field
+		{
+			display: inline-block;
 		}
 	}
 	

--- a/app/assets/stylesheets/base/layout.css.scss
+++ b/app/assets/stylesheets/base/layout.css.scss
@@ -30,7 +30,7 @@ header { }
 // main content and sidebar
 main, aside
 {
-	margin: 4em 0 0;
+	margin: 3em 0 0;
 	padding-bottom: 15em;
 
 	@media #{$small}

--- a/app/assets/stylesheets/modules/dialog.css.scss
+++ b/app/assets/stylesheets/modules/dialog.css.scss
@@ -1,6 +1,6 @@
 #dialog-overlay
 {
-	position: fixed;
+	position: absolute;
 	top: 0;
 	width: 100%;
 	height: 100%;
@@ -44,3 +44,5 @@
 		}
 	}
 }
+
+header.under-dialog { position: absolute; }

--- a/app/assets/stylesheets/modules/editable.css.scss
+++ b/app/assets/stylesheets/modules/editable.css.scss
@@ -37,3 +37,33 @@
 		padding: 0;
 	}
 }
+
+div.editable-image
+{
+	position: relative;
+	width: 100%;
+	height: 100%;
+	
+	span.overlay
+	{
+		max-height: 0;
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		cursor: pointer;
+		transition: background .5s, max-height .5s, padding .1s;
+		
+		span.overlay-content
+		{
+			display: inline-block;
+			padding: .3em .3em .2em;
+			i.fa { margin-right: .4em; }
+		}
+	}
+	
+	&:hover span.overlay
+	{
+		max-height: 100%;
+	}
+}

--- a/app/assets/stylesheets/modules/social.css.scss
+++ b/app/assets/stylesheets/modules/social.css.scss
@@ -6,4 +6,6 @@
 	{
 		padding: 1em;
 	}
+	
+	.like-button { display: inline-block; }
 }

--- a/app/assets/stylesheets/themes/default/modules/editable.css.scss
+++ b/app/assets/stylesheets/themes/default/modules/editable.css.scss
@@ -1,0 +1,8 @@
+div.editable-image
+{	
+	span.overlay
+	{
+		background-color: rgba(255,255,255,0.7);
+		&:hover { background-color: rgba(255,255,255,0.9); }
+	}
+}

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -9,8 +9,9 @@
 # License::		GNU General Public License (stoffiplayer.com/license)
  
 class AlbumsController < ApplicationController
+	include ImageableController
 
-	before_action :set_album, only: [ :show, :edit, :update, :destroy ]
+	before_action :set_resource, only: [ :show, :edit, :update, :destroy ]
 	before_action :ensure_admin, only: [ :edit, :update, :destroy ]
 	oauthenticate interactive: true, except: [ :index, :show ]
 	respond_to :html, :embedded, :xml, :json
@@ -98,9 +99,14 @@ class AlbumsController < ApplicationController
 	private
 
 	# Use callbacks to share common setup or constraints between actions.
-	def set_album
+	def set_resource
 		not_found('album') and return unless Album.exists? params[:id]
 		@album = Album.find(params[:id])
+	end
+	
+	# Access the resource for this controller.
+	def resource
+		@album
 	end
 
 	# Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -9,7 +9,9 @@
 # License::		GNU General Public License (stoffiplayer.com/license)
 
 class ArtistsController < ApplicationController
-	before_action :set_artist, only: [:show, :edit, :update, :destroy]
+	include ImageableController
+
+	before_action :set_resource, only: [:show, :edit, :update, :destroy]
 	oauthenticate interactive: true, except: [ :index, :show ]
 	before_filter :ensure_admin, except: [ :index, :show ]
 	respond_to :html, :xml, :json
@@ -48,9 +50,14 @@ class ArtistsController < ApplicationController
 	private
 
 	# Use callbacks to share common setup or constraints between actions.
-	def set_artist
+	def set_resource
 		not_found('artist') and return unless Artist.exists? params[:id]
 		@artist = Artist.find(params[:id])
+	end
+	
+	# Access the resource for this controller.
+	def resource
+		@artist
 	end
 
 	# Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/concerns/imageable_controller.rb
+++ b/app/controllers/concerns/imageable_controller.rb
@@ -1,0 +1,31 @@
+module ImageableController
+	extend ActiveSupport::Concern
+	
+	included do
+		before_filter :catch_imageable_edit, only: :edit
+		before_filter :catch_imageable_update, only: :update
+	end
+	
+	def catch_imageable_edit
+		if params.include?(:imageable)
+			set_resource
+			render partial: '/concerns/imageable/edit',
+			       object: resource,
+			       as: :resource and return
+		end
+	end
+	
+	def catch_imageable_update
+		if params.include?(:imageable)
+			set_resource
+			return unless params.include?(:image)
+			images = []
+			params[:image].each do |size,url|
+				next if url.blank?
+				images << { url: url, width: size, height: size }
+			end
+			params.delete :images
+			resource.images_hash = { images: images }
+		end
+	end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,8 +8,9 @@
 # License::     GNU General Public License (stoffiplayer.com/license)
 
 class EventsController < ApplicationController
+	include ImageableController
 	
-	before_action :set_event, only: [:show, :edit, :update, :destroy]
+	before_action :set_resource, only: [:show, :edit, :update, :destroy]
 	before_action :ensure_admin, only: [ :update, :destroy ]
 	oauthenticate interactive: true, except: [ :index, :show ]
 
@@ -74,9 +75,14 @@ class EventsController < ApplicationController
 	private
 	
 	# Use callbacks to share common setup or constraints between actions.
-	def set_event
+	def set_resource
 		not_found('event') and return unless Event.exists? params[:id]
 		@event = Event.find(params[:id])
+	end
+	
+	# Access the resource for this controller.
+	def resource
+		@event
 	end
 
 	# Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/genres_controller.rb
+++ b/app/controllers/genres_controller.rb
@@ -8,8 +8,9 @@
 # License::		GNU General Public License (stoffiplayer.com/license)
 
 class GenresController < ApplicationController
+	include ImageableController
 	
-	before_action :set_genre, only: [:show, :edit, :update, :destroy]
+	before_action :set_resource, only: [:show, :edit, :update, :destroy]
 	before_action :ensure_admin, only: [ :update, :destroy ]
 	oauthenticate interactive: true, except: [ :index, :show ]
 
@@ -71,9 +72,14 @@ class GenresController < ApplicationController
 	private
 	
 	# Use callbacks to share common setup or constraints between actions.
-	def set_genre
+	def set_resource
 		not_found('genre') and return unless Genre.exists? params[:id]
 		@genre = Genre.find(params[:id])
+	end
+	
+	# Access the resource for this controller.
+	def resource
+		@genre
 	end
 
 	# Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -10,12 +10,13 @@
 
 class SongsController < ApplicationController
 	include DuplicatableController
+	include ImageableController
 	
-	before_action :set_song, only: [:show, :edit, :update, :destroy]
+	before_action :set_resource, only: [:show, :edit, :update, :destroy]
+	before_filter :ensure_admin, except: [ :index, :show, :create, :destroy ]
 
 	can_duplicate Song
 	oauthenticate interactive: true, except: [ :index, :show ]
-	before_filter :ensure_admin, except: [ :index, :show, :create, :destroy ]
 	respond_to :html, :xml, :json
 	
 	# GET /songs
@@ -86,9 +87,14 @@ class SongsController < ApplicationController
 	private
 
 	# Use callbacks to share common setup or constraints between actions.
-	def set_song
+	def set_resource
 		not_found('song') and return unless Song.unscoped.exists? params[:id]
 		@song = Song.unscoped.find(params[:id])
+	end
+	
+	# Access the resource for this controller.
+	def resource
+		@song
 	end
 
 	# Never trust parameters from the scary internet, only allow the white list through.

--- a/app/helpers/imageable_helper.rb
+++ b/app/helpers/imageable_helper.rb
@@ -1,0 +1,14 @@
+module ImageableHelper
+	
+	def editable_image_tag(resource, size, options = {})
+		img = image_tag resource.image(size), options
+		overlay = content_tag :span, class: :overlay do
+			content_tag :span, class: 'overlay-content' do
+				icon('image')+t('imageable.edit.link')
+			end
+		end
+		content_tag :div, img+overlay, class: 'editable-image', data: {
+			imageable_url: url_for([resource, l: current_locale, imageable: true, action: :edit])
+		}
+	end
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -4,6 +4,12 @@ class Image < ActiveRecord::Base
 	validates :url, uniqueness: true
 	
 	def self.create_by_hashes(hashes)
+		images = new_by_hashes(hashes)
+		images.map(&:save!)
+		return images
+	end
+	
+	def self.new_by_hashes(hashes)
 		images = []
 		return images unless hashes.is_a? Array
 		hashes.each do |hash|
@@ -14,7 +20,7 @@ class Image < ActiveRecord::Base
 					hash[:width] = size[0]
 					hash[:height] = size[1]
 				end
-				images << Image.create(
+				images << Image.new(
 					url: hash[:url],
 					width: hash[:width].to_i,
 					height: hash[:height].to_i

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -5,7 +5,7 @@ class Image < ActiveRecord::Base
 	
 	def self.create_by_hashes(hashes)
 		images = new_by_hashes(hashes)
-		images.map(&:save!)
+		images.map(&:save)
 		return images
 	end
 	

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -40,7 +40,7 @@
 		</div>
 		<div class='image'>
 			<div class='image-border'>
-				<%= image_tag @album.image(:huge), data: { field: :picture } %>
+				<%= editable_image_tag @album, :huge, data: { field: :picture } %>
 			</div>
 		</div>
 	</section>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -37,7 +37,7 @@
 		</div>
 		<div class='image'>
 			<div class='image-border'>
-				<%= image_tag @artist.image(:huge), data: { field: :picture } %>
+				<%= editable_image_tag @artist, :huge, data: { field: :picture } %>
 			</div>
 		</div>
 	</section>

--- a/app/views/concerns/imageable/_edit.html.erb
+++ b/app/views/concerns/imageable/_edit.html.erb
@@ -1,0 +1,23 @@
+<h1><%= t 'imageable.edit.title' %></h1>
+<%= form_for resource do |f| %>
+
+	<%= hidden_field_tag :imageable, 1 %>
+	
+	<% [32,64,128,256,512].each do |size| %>
+		<div class='previewable'>
+			<div class='field'>
+				<%= label_tag "image_#{size}", t("imageable.label", size: size) %>
+				<%= url_field_tag "image[#{size}]", resource.image(size, default: '', exact: true), class: :wide,
+					data: { preview: "preview_#{size}" } %>
+			</div>
+			<% w = h = [64,size].min %>
+			<%= image_tag '', width: w, height: h, id: "preview_#{size}", class: 'preview', data: { preview_size: size } %>
+		</div>
+	<% end %>
+	
+	<%= link_to '#', class: 'button', data: { button: :submit } do %>
+		<%= image_tag 'gfx/buttons/save.png' %>
+		<span><%=t 'save' %></span>
+	<% end %>
+		
+<% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -37,7 +37,7 @@
 		</div>
 		<div class='image'>
 			<div class='image-border'>
-				<%= image_tag @event.image(:huge), data: { field: :picture } %>
+				<%= editable_image_tag @event, :huge, data: { field: :picture } %>
 			</div>
 		</div>
 	</section>

--- a/app/views/genres/show.html.erb
+++ b/app/views/genres/show.html.erb
@@ -37,7 +37,7 @@
 		</div>
 		<div class='image'>
 			<div class='image-border'>
-				<%= image_tag @genre.image(:huge), data: { field: :picture } %>
+				<%= editable_image_tag @genre, :huge, data: { field: :picture } %>
 			</div>
 		</div>
 	</section>

--- a/app/views/songs/show.html.erb
+++ b/app/views/songs/show.html.erb
@@ -46,7 +46,7 @@
 		</div>
 		<div class='image'>
 			<div class='image-border'>
-				<%= image_tag @song.image(:huge) %>
+				<%= editable_image_tag @song, :huge, data: { field: :picture } %>
 			</div>
 		</div>
 	</section>

--- a/config/locales/concerns/imageable/se.yml
+++ b/config/locales/concerns/imageable/se.yml
@@ -1,0 +1,6 @@
+se:
+  imageable:
+    edit:
+      link: 'Byt bild'
+      title: 'Ändra bilder'
+    label: "URL till bild på %{size}x%{size}px"

--- a/config/locales/concerns/imageable/us.yml
+++ b/config/locales/concerns/imageable/us.yml
@@ -1,0 +1,7 @@
+us:
+  imageable:
+    edit:
+      link: 'Change image'
+      title: 'Edit images'
+    label: "URL to image of %{size}x%{size}px"
+    

--- a/test/fixtures/images.yml
+++ b/test/fixtures/images.yml
@@ -1,6 +1,6 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-tiny:
+micro:
   url: http://bar.com/tiny.jpg
   resource: not_afraid (Song)
   width: 16

--- a/test/helpers/imageable_helper_test.rb
+++ b/test/helpers/imageable_helper_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+require 'font-awesome-sass'
+
+class ImageableHelperTest < ActionView::TestCase
+	
+	include I18nHelper
+	include FontAwesome::Sass::Rails::ViewHelpers
+	
+	test 'should create editable image' do
+		a = Album.first
+		path = a.image(:huge)
+		options = { width: 100, height: 100 }
+		i = editable_image_tag a, :huge, options
+		assert i.include?(image_tag(path, options))
+	end
+end

--- a/test/models/concerns/imageable_test.rb
+++ b/test/models/concerns/imageable_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class ImageableTest < ActiveSupport::TestCase
+	
+	setup do
+		@song = songs(:one_love)
+	end
+	
+	test "should create images" do
+		assert_difference "@song.images.count", 1, "Didn't create new image" do
+			@song.images_hash = { images: [
+				{
+					url: 'test.com/image.png',
+					width: 42,
+					height: 42
+				}
+			] }
+		end
+		image = Image.find_by(url: 'test.com/image.png')
+		assert_includes @song.images, image, "New image was not assigned to song"
+	end
+	
+	test "should not create duplicates" do
+		assert_no_difference "@song.images.count", "Created new image with duplicate url" do
+			@song.images_hash = { images: [
+				{ url: @song.images.first.url }
+			] }
+		end
+	end
+	
+	test "should update images for existing sizes" do
+		assert_no_difference "@song.images.count", "Number of images changed" do
+			@song.images_hash = { images: [
+				{
+					url: 'test.com/image.png',
+					width: @song.images.first.width,
+					height: @song.images.first.height
+				}
+			] }
+		end
+		assert @song.images.any? { |x| x.url == "test.com/image.png" }, "Didn't assign new url"
+	end
+	
+end


### PR DESCRIPTION
Create a dialog which can be opened by clicking
on the image of a resource. The dialog lists
a number of sizes and allows an admin to set the
URL of the image for that size, along with a
preview of the image.

Create a helper method for adding an overlay
over an image with a link to open the dialog,
along with a concern for controllers to edit
and update images from the dialog.

Turn this on for the following resources:
- Albums
- Artists
- Events
- Genres
- Songs