### PR TITLE
allow songs to be reordered

### DIFF
--- a/app/assets/javascripts/modules/list.js.coffee
+++ b/app/assets/javascripts/modules/list.js.coffee
@@ -1,4 +1,22 @@
+saveSorting = (element) ->
+	console.log 'saveSorting'
+	sortable = $(element).closest "[data-list-sortable]"
+	console.log 'url: ' + sortable.attr('data-list-sortable')
+	$.ajax {
+		url: sortable.attr('data-list-sortable')
+		data: $(element).sortable('serialize')
+		method: 'PATCH'
+		error: () ->
+			$(element).sortable('cancel')
+	}
+
 $(document).on 'contentReady', () ->
+			
+	$("[data-list-sortable]").sortable({
+		items: 'li:not([data-list-add])',
+		update: (event) ->
+			saveSorting $(@)
+	})
 	
 	# problem:
 	# we have an overlay which is shown on hover, but there is no hover on touch

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -10,10 +10,15 @@
  
 class AlbumsController < ApplicationController
 	include ImageableController
+	include SortableController
+	
+	can_sort :songs
+	
+	oauthenticate interactive: true, except: [ :index, :show ]
 
 	before_action :set_resource, only: [ :show, :edit, :update, :destroy ]
 	before_action :ensure_admin, only: [ :edit, :update, :destroy ]
-	oauthenticate interactive: true, except: [ :index, :show ]
+	
 	respond_to :html, :embedded, :xml, :json
 	
 	# GET /albums

--- a/app/controllers/concerns/sortable_controller.rb
+++ b/app/controllers/concerns/sortable_controller.rb
@@ -1,0 +1,42 @@
+module SortableController
+	extend ActiveSupport::Concern
+	
+	module ClassMethods
+		
+		def can_sort(resource)
+			@sortable_model = resource.to_s.singularize
+		end
+		
+		def sortable_model
+			@sortable_model
+		end
+	end
+	
+	def sort
+		if params[:format].to_sym != :json
+			render text: 'only json allowed, not '+params[:format], status: :not_found and return 
+			
+		elsif params[self.class.sortable_model].blank?
+			render json: {
+				error: "missing attribute from query: #{self.class.sortable_model}"
+			}, status: :unprocessable_entity and return
+		end
+		
+		set_resource
+		logger.debug "sorting #{resource.class} with id #{resource.id}"
+		
+		collection = self.class.sortable_model.pluralize.to_sym
+		success = resource.sort collection, params[self.class.sortable_model].map(&:to_i)
+		
+		#SyncController.send('update', resource, request) if success
+		respond_to do |format|
+			if success
+				format.html { redirect_to resource }
+				format.json { render json: resource, status: :ok, location: resource } # TODO: render :show + jbuilder
+			else
+				format.html { render :edit }
+				format.json { render json: resource.errors, status: :unprocessable_entity }
+			end
+		end
+	end
+end

--- a/app/controllers/playlists_controller.rb
+++ b/app/controllers/playlists_controller.rb
@@ -8,8 +8,11 @@
 # License::		GNU General Public License (stoffiplayer.com/license)
 
 class PlaylistsController < ApplicationController
+	include SortableController
 	
-	before_action :set_playlist, only: [:show, :edit, :update, :destroy, :follow]
+	can_sort :songs
+	
+	before_action :set_resource, only: [:show, :edit, :update, :destroy, :follow]
 	oauthenticate except: [ :index, :show ]
 	
 	respond_to :html, :embedded, :json, :xml
@@ -262,9 +265,14 @@ class PlaylistsController < ApplicationController
 	private
 
 	# Use callbacks to share common setup or constraints between actions.
-	def set_playlist
+	def set_resource
 		not_found('playlist') and return unless Playlist.exists? params[:id]
 		@playlist = Playlist.find(params[:id])
+	end
+	
+	# Access the resource for this controller.
+	def resource
+		@playlist
 	end
 
 	# Never trust parameters from the scary internet, only allow the white list through.

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -15,12 +15,12 @@ class Album < ActiveRecord::Base
 	include Sourceable
 	include Rankable
 	include Duplicatable
+	include Sortable
 	
 	# associations
-	with_options uniq: true do |assoc|
-		assoc.has_and_belongs_to_many :artists
-		assoc.has_and_belongs_to_many :songs
-	end
+	has_and_belongs_to_many :artists, uniq: true
+	has_many :album_tracks
+	has_many :songs, through: :album_tracks
 	has_many :genres, through: :songs
 	has_many :listens, through: :songs
 	validates :title, presence: true
@@ -34,6 +34,8 @@ class Album < ActiveRecord::Base
 			sources.map(&:name)
 		end
 	end
+	
+	can_sort :songs
 	
 	self.default_image = "gfx/icons/256/missing.png"
 	

--- a/app/models/album_track.rb
+++ b/app/models/album_track.rb
@@ -1,0 +1,13 @@
+# This code is part of the Stoffi Music Player Project.
+# Visit our website at: stoffiplayer.com
+#
+# Author::		Christoffer Brodd-Reijer (christoffer@stoffiplayer.com)
+# Copyright::	Copyright (c) 2015 Simplare
+# License::		GNU General Public License (stoffiplayer.com/license)
+
+# Describes an album track, ie. a song and its position in the album.
+class AlbumTrack < ActiveRecord::Base
+	validates_presence_of :album, :song
+	belongs_to :album
+	belongs_to :song
+end

--- a/app/models/concerns/sortable.rb
+++ b/app/models/concerns/sortable.rb
@@ -1,0 +1,53 @@
+module Sortable
+	extend ActiveSupport::Concern
+	
+	module ClassMethods
+		
+		# Enable sorting on `collection` whenever it is accessed.
+		def can_sort(collection, options = {})
+			options[:join_model] ||= self.reflections[collection].options[:through]
+			options[:attribute] ||= :position
+		
+			# create method for accessing the order collection
+			define_method "ordered_#{collection}" do |*arguments|
+				join_model = options[:join_model]
+				send(collection).
+					select("#{join_model}.#{options[:attribute]},#{collection}.*").
+					order("#{join_model}.#{options[:attribute]}")
+			end
+		end
+	end
+	
+	# sort the `collection` in the order given by `ids`.
+	def sort(collection, ids, options = {})
+		return if send(collection).empty?
+		
+		options[:join_model] ||= self.class.reflections[collection].options[:through]
+		options[:attribute] ||= :position
+		options[:collection_key] ||= collection.to_s.singularize+'_id'
+		
+		join_models = send(options[:join_model]).order(:position)
+		join_model_ids = join_models.map { |x| x.send(options[:collection_key]) }
+		
+		# filter out ids which are not a join_model
+		ids.select! { |x| x.in? join_model_ids }
+		
+		# add missing IDs to end of ids
+		ids.concat join_model_ids.reject { |x| x.in? ids }
+		
+		pos = 0
+		ids.each do |id|
+			begin
+				join_model = join_models.find_by(options[:collection_key] => id)
+				join_model.update_attribute(options[:attribute], pos)
+				logger.debug "pos #{pos}: #{id}"
+				logger.debug "join_model: #{join_model.to_yaml}"
+				logger.debug "attribute: #{options[:attribute]}"
+				pos += 1
+			rescue
+				# noop
+			end
+		end
+	end
+	
+end

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -14,8 +14,10 @@ class Playlist < ActiveRecord::Base
 	include Rankable
 	include Sourceable
 	include Followable
-
-	has_and_belongs_to_many :songs, uniq: true do
+	include Sortable
+	
+	has_many :playlists_songs
+	has_many :songs, through: :playlists_songs do
 		def page(limit=25, offset=0)
 			all(limit: limit, offset: offset)
 		end
@@ -32,6 +34,7 @@ class Playlist < ActiveRecord::Base
 	validates :name, uniqueness: { scope: :user_id, case_sensitive: false }
 	
 	followable_by User
+	can_sort :songs
 	
 	searchable do
 		text :name, boost: 5

--- a/app/models/playlists_song.rb
+++ b/app/models/playlists_song.rb
@@ -1,0 +1,13 @@
+# This code is part of the Stoffi Music Player Project.
+# Visit our website at: stoffiplayer.com
+#
+# Author::		Christoffer Brodd-Reijer (christoffer@stoffiplayer.com)
+# Copyright::	Copyright (c) 2015 Simplare
+# License::		GNU General Public License (stoffiplayer.com/license)
+
+# Describes a playlist track, ie. a song and its position in the playlist.
+class PlaylistsSong < ActiveRecord::Base
+	validates_presence_of :playlist, :song
+	belongs_to :playlist
+	belongs_to :song
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -21,7 +21,6 @@ class Song < ActiveRecord::Base
 
 	# associations
 	with_options uniq: true do |assoc|
-		assoc.has_and_belongs_to_many :albums
 		assoc.has_and_belongs_to_many :users
 		assoc.has_and_belongs_to_many :playlists
 		assoc.has_and_belongs_to_many :genres
@@ -38,6 +37,8 @@ class Song < ActiveRecord::Base
 		assoc.has_many :images
 		assoc.has_many :shares
 	end
+	has_many :album_tracks
+	has_many :albums, through: :album_tracks
 	has_many :listens
 	
 	# include duplicates' association into self's

--- a/app/views/albums/sections/_songs.html.erb
+++ b/app/views/albums/sections/_songs.html.erb
@@ -2,6 +2,7 @@
 	<%
 	add_button_options = false
 	delete_options = false
+	data = { album: @album.id }
 	
 	if current_user.admin?
 		add_button_options = {
@@ -14,14 +15,18 @@
 			method: :put,
 			data: "{ songs: { removed: [song.id] } }"
 		}
+		
+		data[:sortable] = sort_album_path(@album, format: :json)
 	end
+	
+	
 	%>
 	<%= render partial: 'shared/lists/list', locals:
 	{
-		collection: @album.songs,
+		collection: @album.ordered_songs,
 		resource: 'songs',
 		show_add_button: add_button_options,
-		data: { album: @album.id },
+		data: data,
 		delete: delete_options
 	} %>
 </section>

--- a/app/views/playlists/sections/_songs.html.erb
+++ b/app/views/playlists/sections/_songs.html.erb
@@ -10,10 +10,10 @@
 	%>
 	<%= render partial: 'shared/lists/list', locals:
 	{
-		collection: @playlist.songs,
+		collection: @playlist.ordered_songs,
 		resource: 'songs',
 		show_add_button: add_button_options,
-		data: { playlist: @playlist.id },
+		data: { playlist: @playlist.id, sortable: sort_playlist_path(@playlist, format: :json) },
 		delete:
 		{
 			url: playlist_path(@playlist, format: :json),

--- a/app/views/songs/_song.html.erb
+++ b/app/views/songs/_song.html.erb
@@ -1,5 +1,5 @@
 <li class='item' data-href='<%= url_for song %>' data-resource-type='song' data-resource-id='<%= song.id %>'
-	data-resource-url='<%= url_for(song) %>'>
+	data-resource-url='<%= url_for(song) %>' id='song_<%= song.id %>'>
 	
 	<!-- image -->
 	<%= image_tag song.image(:huge), data: { field: 'picture' } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,7 +97,7 @@ Stoffi::Application.routes.draw do
 		
 		resources :links, only: [:index, :show, :create, :update, :destroy]
 		
-		resources :artists, :events, :songs, :genres, :albums
+		resources :artists, :events, :songs, :genres
 		
 		resources :listens do
 			member do
@@ -105,9 +105,16 @@ Stoffi::Application.routes.draw do
 			end
 		end
 		
+		resources :albums do
+			member do
+				patch 'sort'
+			end
+		end
+		
 		resources :playlists do
 			member do
 				put 'follow'
+				patch 'sort'
 			end
 			collection do
 				get '/by/:user_id', to: 'playlists#by'

--- a/db/migrate/20150707210428_create_album_track.rb
+++ b/db/migrate/20150707210428_create_album_track.rb
@@ -1,0 +1,7 @@
+class CreateAlbumTrack < ActiveRecord::Migration
+  def change
+    rename_table :albums_songs, :album_tracks
+    add_column :album_tracks, :id, :primary_key
+    add_column :album_tracks, :position, :integer
+  end
+end

--- a/db/migrate/20150708220317_add_position_to_playlists_songs.rb
+++ b/db/migrate/20150708220317_add_position_to_playlists_songs.rb
@@ -1,0 +1,6 @@
+class AddPositionToPlaylistsSongs < ActiveRecord::Migration
+  def change
+    add_column :playlists_songs, :id, :primary_key
+    add_column :playlists_songs, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150410165947) do
+ActiveRecord::Schema.define(version: 20150708220317) do
 
   create_table "admin_configs", force: true do |t|
     t.string   "name"
@@ -41,6 +41,14 @@ ActiveRecord::Schema.define(version: 20150410165947) do
     t.datetime "updated_at"
   end
 
+  create_table "album_tracks", force: true do |t|
+    t.integer "song_id"
+    t.integer "album_id"
+    t.integer "position"
+  end
+
+  add_index "album_tracks", ["album_id", "song_id"], name: "by_album_and_song", unique: true
+
   create_table "albums", force: true do |t|
     t.string   "title"
     t.integer  "year"
@@ -59,13 +67,6 @@ ActiveRecord::Schema.define(version: 20150410165947) do
   end
 
   add_index "albums_artists", ["artist_id", "album_id"], name: "by_album_and_artist", unique: true
-
-  create_table "albums_songs", id: false, force: true do |t|
-    t.integer "song_id"
-    t.integer "album_id"
-  end
-
-  add_index "albums_songs", ["album_id", "song_id"], name: "by_album_and_song", unique: true
 
   create_table "artists", force: true do |t|
     t.string   "name"
@@ -418,9 +419,10 @@ ActiveRecord::Schema.define(version: 20150410165947) do
 
   add_index "playlists", ["user_id", "name"], name: "by_user_and_name", unique: true
 
-  create_table "playlists_songs", id: false, force: true do |t|
+  create_table "playlists_songs", force: true do |t|
     t.integer "playlist_id"
     t.integer "song_id"
+    t.integer "position"
   end
 
   add_index "playlists_songs", ["playlist_id", "song_id"], name: "by_playlist_and_song", unique: true

--- a/test/controllers/concerns/sortable_controller_test.rb
+++ b/test/controllers/concerns/sortable_controller_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class SortableControllerTest < ActionController::TestCase
+	include Devise::TestHelpers
+	
+	setup do
+		@admin = users(:alice)
+		@album = albums(:best_of_bob_marley)
+		@controller = AlbumsController.new
+	end
+
+	test "should order songs in album" do
+		sign_in @admin
+		
+		current_order = @album.songs.map(&:id)
+		new_order = current_order.shuffle
+		
+		# verify current order
+		assert_equal current_order, @album.songs.map(&:id), "Wasn't in correct original order"
+		
+		# sort
+		patch :sort, id: @album, format: :json, song: new_order
+		assert_response :success
+		
+		# verify new order
+		assert_equal new_order, @album.ordered_songs.map(&:id), "Didn't change to correct order"
+	end
+end

--- a/test/fixtures/album_tracks.yml
+++ b/test/fixtures/album_tracks.yml
@@ -1,0 +1,39 @@
+relapse_not_afraid:
+  album: relapse
+  song: not_afraid
+  position: 1
+  
+relapse_exodus:
+  album: relapse
+  song: exodus
+  position: 2
+  
+recovery_one_love:
+  album: recovery
+  song: one_love
+  position: 1
+  
+recovery_no_woman_no_cry:
+  album: recovery
+  song: no_woman_no_cry
+  position: 2
+  
+bobob_one_love:
+  album: best_of_bob_marley
+  song: one_love
+  position: 1
+  
+bobob_no_woman_no_cry:
+  album: best_of_bob_marley
+  song: no_woman_no_cry
+  position: 2
+  
+bobob_jamming:
+  album: best_of_bob_marley
+  song: jamming
+  position: 3
+  
+bobob_exodus:
+  album: best_of_bob_marley
+  song: exodus
+  position: 4

--- a/test/fixtures/albums.yml
+++ b/test/fixtures/albums.yml
@@ -1,15 +1,12 @@
 relapse:
   title: Relapse
-  songs: not_afraid, exodus
   artists: bob_marley, eminem
   year: 2014
     
 recovery:
   title: Recovery
   artists: eminem
-  songs: one_love, no_woman_no_cry
   year: 2010
   
 best_of_bob_marley:
   title: The Best of Bob Marley
-  songs: one_love, no_woman_no_cry, jamming, exodus

--- a/test/fixtures/playlists.yml
+++ b/test/fixtures/playlists.yml
@@ -4,24 +4,20 @@ foo:
     name: Foo
     user: alice
     is_public: 1
-    songs: not_afraid, one_love
 
 bar:
     name: Bar
     user: alice
     is_public: 0
     filter: Eminem
-    songs: not_afraid
 
 baz:
     name: Baz
     user: bob
     is_public: 1
     filter: Bob Marley
-    songs: one_love, no_woman_no_cry
 
 car:
     name: Car
     user: bob
     is_public: 1
-    songs: one_love

--- a/test/fixtures/playlists_songs.yml
+++ b/test/fixtures/playlists_songs.yml
@@ -1,0 +1,23 @@
+foo_not_afraid:
+  playlist: foo
+  song: not_afraid
+
+foo_one_love:
+  playlist: foo
+  song: one_love
+
+bar_not_afraid:
+  playlist: bar
+  song: not_afraid
+  
+baz_one_love:
+  playlist: baz
+  song: one_love
+  
+baz_one_love:
+  playlist: baz
+  song: no_woman_no_cry
+  
+car_one_love:
+  playlist: car
+  song: one_love

--- a/test/models/concerns/sortable_test.rb
+++ b/test/models/concerns/sortable_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class SortableTest < ActiveSupport::TestCase
+	
+	setup do
+		@album = albums(:best_of_bob_marley)
+	end
+	
+	test "should sort songs" do
+		current_order = @album.songs.map(&:id)
+		new_order = current_order.shuffle
+		
+		# verify current order
+		assert_equal current_order, @album.songs.map(&:id), "Wasn't in correct original order"
+		
+		# sort
+		@album.sort :songs, new_order
+		
+		# verify new order
+		assert_equal new_order, @album.ordered_songs.map(&:id), "Didn't change to correct order"
+	end
+	
+end


### PR DESCRIPTION
Create a Sortable concern (models and controllers) which allows
associations (`has_many :through`) to be sorted using the attribute
`position` on the join table.

Resources are reordered in the view using `sortable` from jQuery UI
which fires of an AJAX request after each sorting.

Playlists and Albums are made sortable.

This fixes #19.