### PR TITLE
Improve management of duplicates

### DIFF
--- a/app/assets/javascripts/modules/dialog.js.coffee
+++ b/app/assets/javascripts/modules/dialog.js.coffee
@@ -20,6 +20,7 @@ isOpening = false
 		$('#dialog-overlay').css 'left', p.offset().left
 	else
 		$('#dialog-overlay').removeAttr 'style'
+		repositionDialog(true)
 	
 	$('#dialog #content').hide()
 	$('#dialog .alert').hide()
@@ -42,6 +43,12 @@ isOpening = false
 			$('#dialog #content').show()
 	}
 	
+repositionDialog = (force = false) ->
+	margin = 50
+	top = $(document).scrollTop() + margin
+	if force or parseInt($('#dialog').css('margin-top')) > top
+		$('#dialog').css 'margin-top', top
+	
 $ ->
 	$('body').on 'click', (event) ->
 		if event.which == 1 and (
@@ -50,3 +57,8 @@ $ ->
 			return
 		if $('#dialog-overlay').is(':visible') and not isOpening
 			closeDialog()
+			
+	$(document).when 'scroll.dialog', (event) ->
+		repositionDialog()
+			
+		

--- a/app/assets/javascripts/modules/duplicatable.js.coffee
+++ b/app/assets/javascripts/modules/duplicatable.js.coffee
@@ -27,6 +27,26 @@ toggleDuplicate = (element, event) ->
 			refreshDuplicate element
 	}
 
+#
+# Open a dialog to find duplicates of a resource.
+#
+findDuplicatesClicked = (element) ->
+	url = element.data('duplicatable-url')
+	openDialog url
+	
+markAsDuplicateClicked = (element) ->
+	url = element.closest('#find-duplicates').data 'duplicatable-url'
+	id = element.data 'resource-id'
+	type = element.data 'resource-type'
+	$.ajax {
+		method: 'patch',
+		url: url+'.json',
+		dataType: 'html',
+		data: "#{type}[]=#{id}",
+		success: (data, status, jqXHR) ->
+			element.toggle()
+	}
+
 $(document).on 'contentReady', () ->
 	for element in $("a[data-ajax-call='duplicate']")
 		refreshDuplicate $(element)
@@ -35,3 +55,10 @@ $(document).on 'contentReady', () ->
 			event.stopPropagation()
 			event.preventDefault()
 			toggleDuplicate($(@), event)
+			
+	$('[data-duplicatable-url]').when 'click.find_duplicates', (event) ->
+		findDuplicatesClicked $(@)
+		
+	$('#find-duplicates #search-results .item').when 'click.mark_duplicates', (event) ->
+		markAsDuplicateClicked $(@)
+		event.stopPropagation()

--- a/app/assets/stylesheets/modules/duplicatable.css.scss
+++ b/app/assets/stylesheets/modules/duplicatable.css.scss
@@ -1,4 +1,4 @@
-#edit-playlist
+#find-duplicates
 {
 	min-width: 25em;
 }

--- a/app/assets/stylesheets/pages/search.css.scss
+++ b/app/assets/stylesheets/pages/search.css.scss
@@ -109,3 +109,5 @@
 		}
 	}
 }
+
+#search-results { text-align: left; }

--- a/app/controllers/concerns/duplicatable_controller.rb
+++ b/app/controllers/concerns/duplicatable_controller.rb
@@ -20,6 +20,28 @@ module DuplicatableController
 		
 	end
 	
+	def find_duplicates
+		set_resource
+		render partial: '/concerns/duplicatable/find', locals: {
+			duplicatable_model: self.class.duplicatable_model.to_s.tableize,
+			resource: resource
+		}
+	end
+	
+	def mark_duplicates
+		set_resource
+		klass = self.class.duplicatable_model.to_s.tableize.singularize.to_sym
+		params[klass].each do |id|
+			begin
+				dup = self.class.duplicatable_model.find(id)
+				dup.duplicate_of resource
+			rescue
+				# no op
+			end
+		end
+		head :ok
+	end
+	
 	private
 	
 	# Automatically redirect to a resource's archetype if it has one

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -64,6 +64,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
 		
 		@configuration = current_user.configurations.first
 		
+		if current_user.admin?
+			@duplicates = Song.top_duplicate_candidates
+		end
+		
 		render layout: (params[:format] == 'embedded' ? 'empty' : true)
 	end
 	

--- a/app/helpers/concerns/duplicatable_helper.rb
+++ b/app/helpers/concerns/duplicatable_helper.rb
@@ -1,0 +1,12 @@
+module Concerns::DuplicatableHelper
+	
+	def mark_as_duplicate_tag(resource, options = {})
+		link_to '#', class: :button, data: {
+			button: true,
+			duplicatable_url: url_for([resource, l: current_locale, action: :find_duplicates])
+		} do
+			content_tag :span, t('duplicatable.link')
+		end
+	end
+	
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -42,7 +42,9 @@ class Song < ActiveRecord::Base
 	has_many :listens
 	
 	# include duplicates' association into self's
-	include_associations_of_dups :listens, :shares, :artists
+	include_associations_of_dups :listens, :shares, :genres
+	
+	find_duplicates_by :title
 	
 	self.default_image = "gfx/icons/256/missing.png"
 	

--- a/app/views/concerns/duplicatable/_find.html.erb
+++ b/app/views/concerns/duplicatable/_find.html.erb
@@ -1,0 +1,18 @@
+<%
+klass = local_assigns[:duplicatable_model]
+url = url_for([local_assigns[:resource], l: params[:l], action: :mark_duplicates])
+%>
+<section id='find-duplicates' data-duplicatable-url='<%= url %>'>
+	<%= form_tag search_url(categories: klass, limit: 5), method: :get, remote: true, data: {
+		loading: 'search-loading'
+	} do %>
+		<div class='field'>
+			<%= text_field_tag :query, nil, autofocus: true, placeholder: t("search.placeholder.#{klass}") %>
+		</div>
+	<% end %>
+	
+	<div id='search-loading'>
+		<%= render 'shared/widgets/loading' %>
+	</div>
+	<ul id='search-results' class='mini list' data-href-stop></ul>
+</section>

--- a/app/views/songs/_song.html.erb
+++ b/app/views/songs/_song.html.erb
@@ -32,8 +32,8 @@
 		<% if current_user.admin? and defined? archetype %>
 			<span class='duplicate action'>
 				<%
-				mark_title = t('duplicates.mark.description', archetype: archetype.title)
-				unmark_title = t('duplicates.unmark.description', archetype: archetype.title)
+				mark_title = t('duplicatable.mark.description', archetype: archetype.title)
+				unmark_title = t('duplicatable.unmark.description', archetype: archetype.title)
 				%>
 				<%= link_to '',
 				 	data: {
@@ -42,10 +42,10 @@
 						duplicate_status: :unmarked
 					} do %>
 					<span data-list-mode='list' data-duplicate-mark title='<%=mark_title%>'>
-						<%= t 'duplicates.mark.link' %>
+						<%= t 'duplicatable.mark.link' %>
 					</span>
 					<span data-list-mode='list' data-duplicate-unmark title='<%=unmark_title%>'>
-						<%= t 'duplicates.unmark.link' %>
+						<%= t 'duplicatable.unmark.link' %>
 					</span>
 				<% end %>
 			</span>

--- a/app/views/songs/sections/_duplicates.html.erb
+++ b/app/views/songs/sections/_duplicates.html.erb
@@ -1,12 +1,24 @@
-<% if @song.duplicates.size > 0 %>
+<% if current_user.admin? %>
+
+	<% if @song.duplicates.size > 0 %>
+		<section>
+			<h1><%= t 'duplicatable.duplicates' %></h1>
+			<ul class='list' data-list='songs'>
+				<%= render partial: 'songs/song', collection: @song.duplicates, locals: {
+					delete: { method: :patch, data: { song: { archetype: nil }}, 
+						title: t('duplicatable.unmark.description', archetype: @song),
+						confirm: '' }
+				} %>
+			</ul>
+		</section>
+	<% end %>
+
 	<section>
-		<h1><%= t 'duplicates.header' %></h1>
+		<h1><%= t 'duplicatable.candidates' %></h1>
 		<ul class='list' data-list='songs'>
-			<%= render partial: 'songs/song', collection: @song.duplicates, locals: {
-				delete: { method: :patch, data: { song: { archetype: nil }}, 
-					title: t('duplicates.unmark.description', archetype: @song),
-					confirm: '' }
-			} %>
+			<%= render partial: 'songs/song', collection: @song.duplicate_candidates,
+				locals: { archetype: @song } %>
 		</ul>
 	</section>
+	
 <% end %>

--- a/app/views/songs/sections/_info.html.erb
+++ b/app/views/songs/sections/_info.html.erb
@@ -35,4 +35,8 @@
 			</li>
 		<% end %>
 	</ul>
+	
+	<p>&nbsp;</p>
+	<%= mark_as_duplicate_tag @song %>
+	
 </section>

--- a/app/views/users/registrations/dashboard.html.erb
+++ b/app/views/users/registrations/dashboard.html.erb
@@ -1,7 +1,12 @@
-<% tabs = ['statistics', 'rankings', 'playlists', 'devices'] %>
+<%
+tabs = {
+	user: ['statistics', 'rankings', 'playlists', 'devices']
+}
+tabs[:admin] = ['duplicates'] if current_user.admin?
+%>
 
 <article class='tabbed'>
-	<% tabs.each do |tab| %>
+	<% tabs.values.flatten.each do |tab| %>
 		<section data-content='<%= tab %>'>
 			<h1><%= t "pages.users.registrations.dashboard.#{tab}.title" %></h1>
 			<%= render "users/registrations/dashboard/#{tab}" %>
@@ -10,121 +15,16 @@
 	
 	<aside class='tabs'>
 		<section>
-			<% tabs.each do |tab| %>
-				<div class='tab' data-tab='<%= tab %>' title='<%=t "pages.users.registrations.dashboard.#{tab}.description" %>'>
-					<%=t "pages.users.registrations.dashboard.#{tab}.link" %>
-				</div>
+			<% tabs.keys.each do |category| %>
+				<% unless category == :user %>
+					<h2><%= t "dashboard.categories.#{category}" %></h2>
+				<% end %>
+				<% tabs[category].each do |tab| %>
+					<div class='tab' data-tab='<%= tab %>' title='<%=t "pages.users.registrations.dashboard.#{tab}.description" %>'>
+						<%=t "pages.users.registrations.dashboard.#{tab}.link" %>
+					</div>
+				<% end %>
 			<% end %>
 		</section>
 	</aside>
 </article>
-
-<% if false %>
-
-<article class='fullwidth'>
-	<section>
-		<h1>Dashboard</h1>
-		<%= bar_chart charts_recent_listens_for_user_path %>
-		<%= bar_chart charts_active_users_path %>
-	</section>
-</article>
-
-<div class="white box" id="dashboard">
-
-	<div class="wide">
-
-		<h1><%=t "dashboard.songs.title" %></h1>
-		<% if @songs.length > 0 %>
-			<ul class="horizontal">
-				<% @songs.each do |song| %>
-					<%= item song.title, song, "song-#{song.id}-title", :image => song.image %>
-				<% end %>
-			</ul>
-		<% else %>
-			<p class="message"><%=t "dashboard.songs.empty" %></p>
-		<% end %>
-		
-		<% if text_ads? %>
-			<div class="ad">
-				<script type="text/javascript"><!--
-				google_ad_client = "ca-pub-5639501338860736";
-				/* Front Black */
-				google_ad_slot = "4189875527";
-				google_ad_width = 468;
-				google_ad_height = 60;
-				//-->
-				</script>
-				<script type="text/javascript"
-				src="http://pagead2.googlesyndication.com/pagead/show_ads.js">
-				</script>
-			</div>
-		<% end %>
-		
-		<h1><%=t "dashboard.artists.title" %></h1>
-		<% if @artists.length > 0 %>
-			<ul class="horizontal">
-				<% @artists.each do |artist| %>
-					<%= item artist.name, artist, "artist-#{artist.id}-name", :image => artist.image %>
-				<% end %>
-			</ul>
-		<% else %>
-			<p class="message"><%=t "dashboard.artists.empty" %></p>
-		<% end %>
-		
-		<h1><%=t "dashboard.listens.title" %></h1>
-		<ul class="horizontal" data-list="listens" data-maxLength="10">
-			<% @listens.each do |listen| %>
-				<%= item listen.song.title, listen, "song-#{listen.song.id}-title", :url => url_for(listen.song), :image => listen.song.image %>
-			<% end %>
-		</ul>
-		<p class="message" data-field="no-listens"<%= "style='display:none;'".html_safe if @listens.length > 0 %>>
-			<%=t "dashboard.listens.empty" %>
-		</p>
-	</div>
-
-	<div class="narrow">
-		<h1><%=t "playlists.title.list" %></h1>
-		<ul class="vertical" data-list="playlists">
-			<% @playlists.each do |playlist| %>
-				<%= item playlist.name, playlist, "playlist-#{playlist.id}-name" %>
-			<% end %>
-		</ul>
-		<p class="message" data-field="no-playlists"<%= "style='display:none;'".html_safe if @playlists.length > 0 %>>
-			<%=t "playlists.empty.short" %>
-		</p>
-			
-		<%= custom_button_tag t("create"), new_playlist_path, "", { :color => :blue } %>
-		
-		<h1><%=t "dashboard.support.title" %></h1>
-		<ul class="vertical" data-list="donations">
-			<% @donations.each do |donation| %>
-				<%= item donation.artist.name, donation, "artist-#{donation.artist.id}-name" %>
-			<% end %>
-		</ul>
-		<p class="message" data-field="no-donations"<%= "style='display:none;'".html_safe if @donations.count > 0 %>>
-			<%=t "dashboard.support.empty" %>
-		</p>
-			
-		<%=custom_button_tag t("donations.send"), "donate()", "dollar", { :type => :function, :color => :gold } %>
-		
-		<h1><%=t "dashboard.devices.title" %></h1>
-		<ul class="vertical" data-list="devices">
-			<% @devices.each do |device| %>
-				<%= item device.name, device, "device-#{device.id}-name" %>
-			<% end %>
-		</ul>
-		<p class="message" data-field="no-devices"<%= "style='display:none;'".html_safe if @devices.length > 0 %>>
-			<%=t "devices.empty" %>
-		</p>
-		
-		<h1><%=t "dashboard.remote.title" %></h1>
-		<% if @configuration != nil and @configuration.devices.count > 0 %>
-			<%= custom_button_tag t("dashboard.remote.button"), remote_path, "", { :color => :blue } %>
-		<% else %>
-			<p class="message"><%=t "dashboard.remote.empty" %></p>
-		<% end %>
-	</div>
-	
-</div>
-
-<% end %>

--- a/app/views/users/registrations/dashboard/_duplicates.html.erb
+++ b/app/views/users/registrations/dashboard/_duplicates.html.erb
@@ -1,0 +1,4 @@
+<%= render partial: 'shared/lists/list', locals: {
+	collection: @duplicates,
+	resource: 'songs'
+} %>

--- a/config/locales/concerns/duplicatable/se.yml
+++ b/config/locales/concerns/duplicatable/se.yml
@@ -1,0 +1,13 @@
+se:
+  duplicatable:
+    link: 'Hitta dubbletter'
+    
+    duplicates: 'Dubbletter'
+    candidates: 'Möjliga dubbletter'
+    
+    mark:
+      description: 'Markera som en dubblett av %{archetype}'
+      link: 'Markera som dubblett'
+    unmark:
+      description: 'Avmarkera som en dubblett av %{archetype}'
+      link: 'Ta bort som dubblett'

--- a/config/locales/concerns/duplicatable/us.yml
+++ b/config/locales/concerns/duplicatable/us.yml
@@ -1,0 +1,13 @@
+us:
+  duplicatable:
+    link: 'Find duplicates'
+    
+    duplicates: 'Duplicates'
+    candidates: 'Possible dups'
+      
+    mark:
+      description: 'Mark this as a duplicate of %{archetype}'
+      link: 'Mark as duplicate'
+    unmark:
+      description: 'Unmark this as a duplicate of %{archetype}'
+      link: 'Remove as duplicate'

--- a/config/locales/default/se.yml
+++ b/config/locales/default/se.yml
@@ -86,15 +86,6 @@ se:
     global:
       weekly: "Populärt just nu"
       total: "Bäst genom alla tider"
-      
-  duplicates:
-    header: 'Dubbletter'
-    mark:
-      description: 'Markera som en dubblett av %{archetype}'
-      link: 'Markera som dubblett'
-    unmark:
-      description: 'Avmarkera som en dubblett av %{archetype}'
-      link: 'Ta bort som dubblett'
   
   mail:
     title: "Kontakta oss"

--- a/config/locales/default/us.yml
+++ b/config/locales/default/us.yml
@@ -89,15 +89,6 @@ us:
     global:
       weekly: "Trending right now"
       total: "Best of all time"
-      
-  duplicates:
-    header: 'Duplicates'
-    mark:
-      description: 'Mark this as a duplicate of %{archetype}'
-      link: 'Mark as duplicate'
-    unmark:
-      description: 'Unmark this as a duplicate of %{archetype}'
-      link: 'Remove as duplicate'
   
   mail:
     title: "Contact us"

--- a/config/locales/models/users/se.yml
+++ b/config/locales/models/users/se.yml
@@ -13,6 +13,9 @@ se:
       month: 'Denna månad'
       year: 'Detta år'
       alltime: 'Någonsin'
+      
+    categories:
+      admin: 'Admin'
     
   user:
     name:

--- a/config/locales/models/users/us.yml
+++ b/config/locales/models/users/us.yml
@@ -13,6 +13,9 @@ us:
       month: 'This month'
       year: 'This year'
       alltime: 'All time'
+      
+    categories:
+      admin: 'Admin'
     
   user:
     name:

--- a/config/locales/pages/models/se.yml
+++ b/config/locales/pages/models/se.yml
@@ -153,14 +153,14 @@ se:
     songs:
       show:
         description: "Lyssna på %{song} i Stoffi Musikspelare eller direkt här på hemsidan."
-      lastfm:
-        title: '%{song} på Last.fm'
-        link: 'Last.fm'
-        description: 'Kolla in %{song} på Last.fm'
-      info:
-        title: 'Mer info'
-        link: 'Info'
-        description: 'Se mer info om %{song}'
+        lastfm:
+          title: '%{song} på Last.fm'
+          link: 'Last.fm'
+          description: 'Kolla in %{song} på Last.fm'
+        info:
+          title: 'Mer info'
+          link: 'Info'
+          description: 'Se mer info om %{song}'
         
       new:
         link: 'Lägg till låt'

--- a/config/locales/pages/users/se.yml
+++ b/config/locales/pages/users/se.yml
@@ -36,6 +36,11 @@ se:
               link: 'Spellistor'
               description: 'Se dina spellistor.'
               title: 'Spellistor'
+
+          duplicates:
+              link: 'Dubbletter'
+              description: 'Se potentiella dubbletter.'
+              title: 'Dubbletter'
   
         edit:
           link:            'Inställningar'

--- a/config/locales/pages/users/us.yml
+++ b/config/locales/pages/users/us.yml
@@ -37,6 +37,11 @@ us:
               link: 'Playlists'
               description: 'View your playlists.'
               title: 'Playlists'
+
+          duplicates:
+              link: 'Duplicates'
+              description: 'View potential duplicates.'
+              title: 'Duplicates'
   
         edit:
           link:            'Settings'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,7 +97,14 @@ Stoffi::Application.routes.draw do
 		
 		resources :links, only: [:index, :show, :create, :update, :destroy]
 		
-		resources :artists, :events, :songs, :genres
+		resources :artists, :events, :genres
+		
+		resources :songs do
+			member do
+				get 'find_duplicates'
+				patch 'mark_duplicates'
+			end
+		end
 		
 		resources :listens do
 			member do

--- a/test/models/concerns/duplicatable_test.rb
+++ b/test/models/concerns/duplicatable_test.rb
@@ -87,21 +87,21 @@ class DuplicatableTest < ActiveSupport::TestCase
 	test "should combine habtm relation" do
 		song_a = songs(:one_love)
 		song_b = songs(:not_afraid)
-		artist = artists(:damian_marley)
-		song_a.artists << artist
-		song_b.artists << artist
+		genre = genres(:rap)
+		song_a.genres << genre unless song_a.genres.include? genre
+		song_b.genres << genre unless song_b.genres.include? genre
 		song_a.duplicate_of song_b
 		
 		checked = []
-		(song_a.artists + song_b.artists).each do |a|
-			next if a.in? checked
-			assert_includes song_b.artists, a, "Artist #{a} not included in song #{song_b}"
-			checked << a
+		(song_a.genres + song_b.genres).each do |genre|
+			next if genre.in? checked
+			assert_includes song_b.genres, genre, "Genre #{genre} not included in song #{song_b}"
+			checked << genre
 		end
-		song_b.artists.each do |a|
-			assert_includes checked, a, "Artist #{a} should not be included in song #{song_b}"
+		song_b.genres.each do |genre|
+			assert_includes checked, genre, "Genre #{genre} should not be included in song #{song_b}"
 		end
-		assert_equal checked.size, song_b.artists.count, "There are duplicates"
+		assert_equal checked.size, song_b.genres.count, "There are duplicates"
 	end
 	
 	test "should fail to duplicate different models" do


### PR DESCRIPTION
### "Find duplicates" button on song page
Create a button, *Find duplicates*, on `songs#show` which displays a
dialog with a search box. When songs are clicked in the search results
they are marked as duplicates.

### List possible duplicates on song page
Add the method `Duplicatable#duplicate_candidates` which returns a list
of possible duplicates of the given resource. Use this method to list
possible duplicates on `songs#show` for admins.

### List possible duplicates on dashboard
Add a new tab on `user#dashboard`, visible only for admins, where the
songs with the highest number of potential duplicates are listed.