### PR TITLE
Allow setting debug mode via env var

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local       = ENV.key?('DEBUG_MODE')
   config.action_controller.perform_caching = true
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
@@ -42,7 +42,7 @@ Rails.application.configure do
   config.force_ssl = ENV.key?('SSL')
 
   # Set to :debug to see everything in the log.
-  config.log_level = :info
+  config.log_level = (ENV.key?('DEBUG_MODE') ? :debug : :info)
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
Setting the environment variable `DEBUG_MODE` to true turns on debug error messages and debug level in the log files. This helps in tracking down bugs in Heroku while staying in production mode.