### PR TITLE
CI: sleep for 3s after starting solr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
 - RAILS_ENV=test bundle exec rake db:migrate --trace
 - bundle exec rake db:test:prepare
 - RAILS_ENV=test bundle exec rake sunspot:solr:start
+- sleep 3
 - bundle exec rake
 before_script:
 - cp config/database.travis.yml config/database.yml


### PR DESCRIPTION
After getting some errors during CI, caused by Solr not being up and running, a sleep of three seconds is added right after starting solr just to make sure its running before the tests are run.