### PR TITLE
Fix OAuth buttons

### DIFF
--- a/app/helpers/oauth_helper.rb
+++ b/app/helpers/oauth_helper.rb
@@ -1,0 +1,33 @@
+module OauthHelper
+	
+	# Create an OAuth button.
+	def oauth_button(provider, options = {})
+		options[:path] ||= provider.downcase
+		options[:height] ||= 16
+		options[:image] ||= "auth_buttons/#{provider.downcase}_#{options[:height]}_white.png"
+		options[:tooltip] ||= t('auth.login', service: provider.downcase)
+		options[:class] ||= 'auth'
+		
+		img = image_tag(options[:image], width: options[:width], height: options[:height])
+		path = "/auth/#{options[:path]}"
+		
+		link_to img, path, class: options[:class], title: options[:tooltip]
+	end
+	
+	# Create OAuth buttons.
+	def oauth_buttons
+		providers = [
+			'Facebook', 'Twitter', 'Google',
+			'Vimeo', 'LinkedIn', 'SoundCloud'
+		].map do |provider|
+			
+			path = case provider
+			when 'Google' then 'google_oauth2'
+			when 'LinkedIn' then 'linked_in'
+			else provider.downcase end
+				
+			oauth_button(provider, path: path)
+		end.join.html_safe
+	end
+	
+end

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,34 +1,3 @@
-<%
-services = [
-	{
-		name: 'Twitter',
-		width: 21
-	},
-	{
-		name: 'Facebook',
-		width: 10
-	},
-	{
-		name: 'Google',
-		path: 'google_oauth2',
-		width: 15
-	},
-	{
-		name: 'Vimeo',
-		width: 17
-	},
-	{
-		name: 'LinkedIn',
-		path: 'linked_in',
-		width: 19
-	},
-	{
-		name: 'SoundCloud',
-		width: 26
-	}
-]
-%>
-
 <header>
 	<nav>
 		<%= link_to image_tag("gfx/home.png"), root_path, class: "logo" + (@tab == 'index' ? ' active' : '') %>
@@ -67,11 +36,9 @@ services = [
 			</div>
 		
 		<% else %>
-			<%= link_to t("pages.users.sessions.new.link"), new_user_session_path, title: t("pages.users.sessions.new.description") %>
-			<% services.each do |s| %>
-				<%= link_to image_tag("auth_buttons/#{s[:name].downcase}_16_white.png", width: s[:width], height: 16),
-					s[:path] || s[:name].downcase, class: 'auth', title: t('auth.login', service: s[:name])%>
-			<% end %>
+			<%= link_to t("pages.users.sessions.new.link"), new_user_session_path,
+				title: t("pages.users.sessions.new.description") %>
+			<%= oauth_buttons %>
 		<% end %>
 			
 	</nav>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -7,7 +7,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 	provider :facebook, c['facebook']['id'], c['facebook']['key'],
 	{
 		:client_options => {:ssl => {:ca_path => "/etc/ssl/certs"}},
-		:scope => 'publish_actions, offline_access'
+		:scope => 'publish_actions'
 	}
 		
 	provider :twitter, c['twitter']['id'], c['twitter']['key']


### PR DESCRIPTION
Create helper methods for displaying OAuth buttons, so we can share
code between the header and the login page.

Facebook has removed the permission `offline_access`, causing it to
throw an error whenever we try to auth against it using that
permission. Solution is to just remove it.

This fixes #21.