### PR TITLE
Improve and polish search

### DIFF
--- a/app/assets/stylesheets/modules/list.css.scss
+++ b/app/assets/stylesheets/modules/list.css.scss
@@ -151,6 +151,7 @@ ul.list
 	{
 		position: relative;
 		margin: 1em 0;
+		min-height: 5em;
 		
 		[data-list-mode='list'] { display: initial; }
 		

--- a/app/assets/stylesheets/modules/list.css.scss
+++ b/app/assets/stylesheets/modules/list.css.scss
@@ -161,14 +161,18 @@ ul.list
 		{
 			top: 0;
 			padding: 0;
+			overflow: hidden;
+			text-overflow: ellipsis;
 			
 			span.title
 			{
+				max-width: 100%;
 				padding-bottom: 0;
 				font-size: 1.1em;
 			}
 			span.description
 			{
+				max-width: 100%;
 				padding-top: 0;
 				font-size: 1em;
 				a:hover { text-decoration: underline; }

--- a/app/assets/stylesheets/pages/albums.css.scss
+++ b/app/assets/stylesheets/pages/albums.css.scss
@@ -6,6 +6,8 @@ ul.list .item
 	}
 	.album-back
 	{
+		position: relative;
+		top: .35em;
 		width: 64px;
 		height: 56px;
 		background-size: cover;

--- a/app/assets/stylesheets/pages/search.css.scss
+++ b/app/assets/stylesheets/pages/search.css.scss
@@ -7,6 +7,7 @@
 	{
 		@media #{$small}
 		{
+			font-size: .8em;
 			display: block;
 			[data-tab='genres'] { display: none; }
 			[data-tab='events'] { display: none; }
@@ -32,11 +33,18 @@
 	#form
 	{
 		margin: 0;
+		form
+		{
+			@media #{$small} { width: 90%; }
+			@media #{$tiny} { width: 100%; }
+		}
 		#query
 		{
 			width: 30em;
 			padding: .3em .2em;
 			font-size: 1.5em;
+			
+			@media #{$small} { width: 100%; }
 			
 			&.small
 			{
@@ -45,7 +53,7 @@
 			
 				@media #{$small}
 				{
-					width: 20em;
+					width: 15em;
 					font-size: 1.2em;
 				}
 			}
@@ -80,6 +88,8 @@
 	{
 		margin: 0 3em 3em;
 		text-align: left;
+		
+		@media #{$small} { margin: 0 1em 3em; }
 		
 		.stats
 		{

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -33,6 +33,7 @@ class Album < ActiveRecord::Base
 		string :locations, multiple: true do
 			sources.map(&:name)
 		end
+		integer :archetype_id do 0 end # not duplicatable, but still need to index this field
 	end
 	
 	can_sort :songs

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -38,6 +38,7 @@ class Artist < ActiveRecord::Base
 		string :locations, multiple: true do
 			sources.map(&:name)
 		end
+		integer :archetype_id do 0 end # not duplicatable, but still need to index this field
 	end
 	
 	self.default_image = "gfx/icons/256/artist.png"

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -35,6 +35,7 @@ class Event < ActiveRecord::Base
 		string :locations, multiple: true do
 			sources.map(&:name)
 		end
+		integer :archetype_id do 0 end # not duplicatable, but still need to index this field
 	end
 	
 	def self.find_or_create_by_hash(hash)

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -30,6 +30,7 @@ class Genre < ActiveRecord::Base
 		string :locations, multiple: true do
 			sources.map(&:name)
 		end
+		integer :archetype_id do 0 end # not duplicatable, but still need to index this field
 	end
 	
 	def display

--- a/app/models/playlist.rb
+++ b/app/models/playlist.rb
@@ -47,6 +47,7 @@ class Playlist < ActiveRecord::Base
 		string :locations, multiple: true do
 			sources.map(&:name)
 		end
+		integer :archetype_id do 0 end # not duplicatable, but still need to index this field
 	end
 	
 	def display

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -229,6 +229,10 @@ class Search < ActiveRecord::Base
 			q.keywords(query, minimum_matches: 1)
 			q.with(:locations, sources_array)
 			q.paginate(page: page, per_page: limit)
+			
+			# skip duplicates
+			q.without(:archetype_id)
+			
 		end
 	end
 	

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -51,6 +51,7 @@ class Song < ActiveRecord::Base
 	searchable do
 		text :title, boost: 5
 		text :artist_names
+		integer :archetype_id
 		string :locations, multiple: true do
 			sources.map(&:name)
 		end


### PR DESCRIPTION
### Handle duplicates
Filter out duplicates from being searched in Solr during search. This
caused pagination to be weird as the pagination took place before
duplicates were filtered out by our custom scope, and the total number
of hits included duplicates as well.

The solution is to add `archetype_id` as a field indexed by Solr (hard
set to 0 for non-duplicatable models) and scope the search to exclude
any hits with a non-zero value for that field.

### Polish
- Fix some issues with spacing for album list items.
- Fix some issues with layout on iPhone